### PR TITLE
chore(ci): use meza ubuntu slim runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: "⬇️ Checkout"
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -22,7 +22,7 @@ concurrency:
 
 jobs:
   crowdin:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   crowdin:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/update-patrons.yml
+++ b/.github/workflows/update-patrons.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   update-readme:
-    runs-on: self-hosted
+    runs-on: meza-ubuntu-slim
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Summary

Replace `runs-on: self-hosted` with `runs-on: meza-ubuntu-slim` in 4 GitHub Actions workflow files.

## Validation

- Verified 4 exact runner-label replacements.
- Verified no other staged lines changed.
- `git diff --check` passes.